### PR TITLE
Reduce tarball file size

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "lib",
+    "types"
+  ],
   "scripts": {
     "prepare": "husky install",
     "lint": "eslint src --ext ts",


### PR DESCRIPTION
See https://unpkg.com/browse/@single-spa/import-map-injector@1.0.0/ - we don't need the `.husky` or `src` folders published to npm. Also don't need our dotfiles