### PR TITLE
Allow content-type "application/json"

### DIFF
--- a/src/import-map-injector.ts
+++ b/src/import-map-injector.ts
@@ -25,8 +25,11 @@ injectorImportMaps.forEach((scriptEl) => {
         .then((r: Response) => {
           if (r.ok) {
             if (
-              !acceptedImportmapMimeTypes.includes(
-                r.headers.get("content-type").toLowerCase(),
+              !acceptedImportmapMimeTypes.some((acceptedMimeType) =>
+                r.headers
+                  .get("content-type")
+                  .toLowerCase()
+                  .includes(acceptedMimeType),
               )
             ) {
               throw Error(

--- a/src/import-map-injector.ts
+++ b/src/import-map-injector.ts
@@ -13,6 +13,11 @@ const injectorImportMaps = document.querySelectorAll<HTMLScriptElement>(
   "script[type=injector-importmap]",
 );
 
+const acceptedImportmapMimeTypes = [
+  "application/json",
+  "application/importmap+json",
+];
+
 injectorImportMaps.forEach((scriptEl) => {
   if (scriptEl.src) {
     importMapJsons.push(
@@ -20,8 +25,9 @@ injectorImportMaps.forEach((scriptEl) => {
         .then((r: Response) => {
           if (r.ok) {
             if (
-              r.headers.get("content-type").toLowerCase() !==
-              "application/importmap+json"
+              !acceptedImportmapMimeTypes.includes(
+                r.headers.get("content-type").toLowerCase(),
+              )
             ) {
               throw Error(
                 `${errPrefix} Import map at url '${scriptEl.src}' does not have the required content-type http response header. Must be 'application/importmap+json'`,


### PR DESCRIPTION
Hello, thank you for this repo!

I would like to propose a small change which makes the check on `content-type` less strict.
Even though "application/importmap+json" is maybe more correct for importmaps, I don't see a really good reason why we couldn't allow "application/json" as well?

This PR introduces the changes to accept both these content-types. What do you think about it?

Issue: #11