### PR TITLE
BUG: Fix not loading external import map

### DIFF
--- a/src/import-map-injector.ts
+++ b/src/import-map-injector.ts
@@ -77,6 +77,7 @@ injectorImportMaps.forEach((scriptEl) => {
 if (window["importMapOverrides"]) {
   importMapJsons.push(window["importMapOverrides"].getOverrideMap());
   importMapJsons.push(window["importMapOverrides"].getOverrideScopes());
+  importMapJsons.push(window["importMapOverrides"].getExternalOverrideMap());
 }
 
 const requiresMicroTick = importMapJsons.some(

--- a/src/import-map-injector.ts
+++ b/src/import-map-injector.ts
@@ -77,10 +77,7 @@ injectorImportMaps.forEach((scriptEl) => {
 if (window["importMapOverrides"]) {
   importMapJsons.push(window["importMapOverrides"].getOverrideMap());
   importMapJsons.push(window["importMapOverrides"].getOverrideScopes());
-  if (window["importMapOverrides"].getExternalOverrideMap) {
-    // I think it should always have this, but just in case...
-    importMapJsons.push(window["importMapOverrides"].getExternalOverrideMap());
-  }
+  importMapJsons.push(window["importMapOverrides"].getExternalOverrideMap());
 }
 
 const requiresMicroTick = importMapJsons.some(

--- a/src/import-map-injector.ts
+++ b/src/import-map-injector.ts
@@ -77,7 +77,10 @@ injectorImportMaps.forEach((scriptEl) => {
 if (window["importMapOverrides"]) {
   importMapJsons.push(window["importMapOverrides"].getOverrideMap());
   importMapJsons.push(window["importMapOverrides"].getOverrideScopes());
-  importMapJsons.push(window["importMapOverrides"].getExternalOverrideMap());
+  if (window["importMapOverrides"].getExternalOverrideMap) {
+    // I think it should always have this, but just in case...
+    importMapJsons.push(window["importMapOverrides"].getExternalOverrideMap());
+  }
 }
 
 const requiresMicroTick = importMapJsons.some(


### PR DESCRIPTION
Import map overrides UI has an option to add an external import map URL. When use-injector attribute is used, it defers to import-map-injector to load overrides.

However, import map injector ignores the external import maps.

